### PR TITLE
set API endpoint if exists in config

### DIFF
--- a/lib/toiler/aws/queue.rb
+++ b/lib/toiler/aws/queue.rb
@@ -10,6 +10,7 @@ module Toiler
       def initialize(name, client = nil)
         @name   = name
         @client = client || ::Aws::SQS::Client.new
+        puts @client.config["endpoint"]
         @url    = client.get_queue_url(queue_name: name).queue_url
       end
 

--- a/lib/toiler/utils/environment_loader.rb
+++ b/lib/toiler/utils/environment_loader.rb
@@ -44,9 +44,14 @@ module Toiler
       end
 
       def initialize_aws
+        puts 'Initializing AWS'
+        puts Toiler.options
         return if Toiler.options[:aws].empty?
         ::Aws.config[:region] = Toiler.options[:aws][:region]
+        ::Aws.config[:endpoint] = Toiler.options[:aws][:endpoint] if Toiler.options[:aws][:endpoint]
         set_aws_credentials
+        puts Aws.config[:endpoint]
+        #raise 'Finished Initializing'
       end
 
       def set_aws_credentials

--- a/lib/toiler/version.rb
+++ b/lib/toiler/version.rb
@@ -1,4 +1,4 @@
 # Toiler Version
 module Toiler
-  VERSION = '0.4.0.beta1'.freeze
+  VERSION = '0.4.0.beta2'.freeze
 end


### PR DESCRIPTION
In order to test things locally (using fake_sqs) we need the ability to set a nonstandard endpoint. This commit adds that option