### PR TITLE
RSpec test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,6 @@ gem 'aws-sdk', '~> 2.2'
 group :development do
   gem 'rubocop'
 end
+group :test do
+  gem 'rspec'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     concurrent-ruby (1.0.2)
     concurrent-ruby-edge (0.2.2)
       concurrent-ruby (~> 1.0.2)
+    diff-lcs (1.2.5)
     jmespath (1.2.4)
       json_pure (>= 1.8.1)
     json_pure (1.8.3)
@@ -18,6 +19,19 @@ GEM
       ast (~> 2.2)
     powerpack (0.1.1)
     rainbow (2.1.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     rubocop (0.40.0)
       parser (>= 2.3.1.0, < 3.0)
       powerpack (~> 0.1)
@@ -35,6 +49,7 @@ DEPENDENCIES
   aws-sdk (~> 2.2)
   concurrent-ruby (~> 1.0.0)
   concurrent-ruby-edge (~> 0.2.0)
+  rspec
   rubocop
 
 BUNDLED WITH

--- a/spec/models/fetcher_spec.rb
+++ b/spec/models/fetcher_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+require 'toiler/actor/fetcher'
+RSpec.describe Toiler::Actor::Fetcher, type: :model do
+  let(:queue) { 'default' }
+  let(:client) { double(:aws_sqs_client) }
+
+  before do
+    allow_any_instance_of(Toiler::Actor::Fetcher).to receive(:log).and_return(true)
+    allow_any_instance_of(Toiler::Aws::Queue).to receive(:visibility_timeout).and_return(100)
+    allow(client).to receive(:get_queue_url).with(queue_name: 'default').and_return double(:queue, queue_url: 'http://aws.fake/queue')
+  end
+
+  describe "#new" do
+    it 'completes sucessfully' do
+      fetcher = described_class.new(queue, client)
+      expect(fetcher.polling?).to eq(false)
+      expect(fetcher.executing?).to eq(false)
+      expect(fetcher.scheduled?).to eq(false)
+    end
+  end
+end

--- a/spec/models/processor_spec.rb
+++ b/spec/models/processor_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+require 'toiler/actor/processor'
+RSpec.describe Toiler::Actor::Processor, type: :model do
+  let(:fetcher) { double(:fetcher) }
+
+  describe "#new" do
+    it 'initializes properly' do
+      allow(Toiler).to receive(:fetcher).and_return(fetcher)
+      expect(fetcher).to receive(:tell).with(:processor_finished)
+      processor = described_class.new('default')
+      expect(processor.executing?).to eq(false)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,22 @@
+require 'bundler/setup'
+Bundler.setup
+
+require 'concurrent'
+require 'concurrent-edge'
+Concurrent.use_stdlib_logger Logger::FATAL
+
+require 'toiler'
+class TestWorker
+  include Toiler::Worker
+
+  toiler_options queue: 'default'
+
+  def perform(sqs_message, body); end
+end
+
+require 'rspec'
+RSpec.configure do |config|
+  config.before do
+    allow(Toiler).to receive(:worker_class_registry).and_return({'default' => TestWorker})
+  end
+end


### PR DESCRIPTION
There was no test suite for Toiler, so I added Rspec.

I included 2 preliminary specs to get us going.

The fetcher and processor expect to be launched concurrently, so there is a bit of mocking necessary to use them on their own.  Additionally, since we shouldn't ping out to amazon when running tests, we will have to mock that as well.