### PR TITLE
Active worker class registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ toiler --help
 
     -d, --daemon                     Daemonize process
     -r, --require [PATH|DIR]         Location of the worker
+    -q, --queue QUEUE1,QUEUE2,...    Queues to process
     -C, --config PATH                Path to YAML config file
     -R, --rails                      Load Rails
     -L, --logfile PATH               Path to writable logfile

--- a/lib/toiler.rb
+++ b/lib/toiler.rb
@@ -52,4 +52,8 @@ module Toiler
       batch: false
     }
   end
+
+  def register_worker(queue, worker)
+    @worker_class_registry[queue] = worker
+  end
 end

--- a/lib/toiler.rb
+++ b/lib/toiler.rb
@@ -31,7 +31,14 @@ module Toiler
   def active_worker_class_registry
     active_queues = options[:active_queues]
     if active_queues
-      active_queues.each_with_object({}) {|q, registry| registry[q] = @worker_class_registry[q]}
+      active_queues.each_with_object({}) do |q, registry|
+        worker = @worker_class_registry[q]
+        if worker.nil?
+          logger.warn "No worker assigned to queue: #{q}"
+        else
+          registry[q] = worker
+        end
+      end
     else
       @worker_class_registry
     end

--- a/lib/toiler.rb
+++ b/lib/toiler.rb
@@ -56,4 +56,8 @@ module Toiler
   def register_worker(queue, worker)
     @worker_class_registry[queue] = worker
   end
+
+  def worker_class_registry=(val)
+    @worker_class_registry = val
+  end
 end

--- a/lib/toiler.rb
+++ b/lib/toiler.rb
@@ -28,6 +28,15 @@ module Toiler
     worker_class_registry.keys
   end
 
+  def active_worker_class_registry
+    active_queues = options[:active_queues]
+    if active_queues
+      active_queues.each_with_object({}) {|q, registry| registry[q] = @worker_class_registry[q]}
+    else
+      @worker_class_registry
+    end
+  end
+
   def fetcher(queue)
     fetchers["fetcher_#{queue}".to_sym]
   end

--- a/lib/toiler/actor/supervisor.rb
+++ b/lib/toiler/actor/supervisor.rb
@@ -19,12 +19,8 @@ module Toiler
         pass
       end
 
-      def queues
-        Toiler.worker_class_registry
-      end
-
       def spawn_fetchers
-        queues.each do |queue, _klass|
+        Toiler.active_worker_class_registry.each do |queue, _klass|
           begin
             fetcher = Actor::Fetcher.spawn! name: "fetcher_#{queue}".to_sym,
                                             supervise: true, args: [queue, client]
@@ -36,7 +32,7 @@ module Toiler
       end
 
       def spawn_processors
-        queues.each do |queue, klass|
+        Toiler.active_worker_class_registry.each do |queue, klass|
           name = "processor_pool_#{queue}".to_sym
           count = klass.concurrency
           begin

--- a/lib/toiler/utils/argument_parser.rb
+++ b/lib/toiler/utils/argument_parser.rb
@@ -12,6 +12,10 @@ module Toiler
             opts[:daemon] = arg
           end
 
+          o.on '-q', '--queue QUEUE1,QUEUE2,...', 'Queues to process' do |arg|
+            opts[:active_queues] = arg.split(',')
+          end
+
           o.on '-r', '--require [PATH|DIR]', 'Location of the worker' do |arg|
             opts[:require] = arg
           end

--- a/lib/toiler/worker.rb
+++ b/lib/toiler/worker.rb
@@ -34,7 +34,7 @@ module Toiler
     module ClassMethods
       def toiler_options(options = {})
         return class_variable_get(:@@toiler_options) if options.empty?
-        Toiler.worker_class_registry[options[:queue]] = self if options[:queue]
+        Toiler.register_worker(options[:queue], self) if options[:queue]
         class_variable_get(:@@toiler_options).merge! options
       end
 

--- a/spec/models/supervisor_spec.rb
+++ b/spec/models/supervisor_spec.rb
@@ -17,5 +17,11 @@ RSpec.describe Toiler::Actor::Supervisor, type: :model do
       expect(Concurrent::Actor::Utils::Pool).to receive(:spawn!).with(:processor_pool_default, 1)
       supervisor = described_class.new
     end
+
+    it 'warns when a queue is missing' do
+      Toiler.options.merge!(active_queues: ['missing'])
+      expect(Toiler::Utils::Logging.logger).to receive(:warn).with("No worker assigned to queue: missing")
+      Toiler.active_worker_class_registry
+    end
   end
 end

--- a/spec/models/supervisor_spec.rb
+++ b/spec/models/supervisor_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+require 'toiler/actor/supervisor'
+RSpec.describe Toiler::Actor::Supervisor, type: :model do
+  let(:sqs_client) { double(:client) }
+  describe "#new" do
+    it 'only spawns fetchers for active workers' do
+      class InactiveWorker
+        include Toiler::Worker
+        toiler_options queue: 'inactive_queue'
+        def perform(sqs_message, body); end
+      end
+
+      Toiler.options.merge!(active_queues: ['default'])
+      expect(::Aws::SQS::Client).to receive(:new).and_return(sqs_client)
+      expect(Toiler::Actor::Fetcher).to receive(:spawn!).with(name: :fetcher_default, supervise: true, args: ['default', sqs_client])
+      expect(Concurrent::Actor::Utils::Pool).to receive(:spawn!).with(:processor_pool_default, 1)
+      supervisor = described_class.new
+    end
+  end
+end

--- a/spec/models/worker_spec.rb
+++ b/spec/models/worker_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 require 'toiler/worker'
 RSpec.describe Toiler::Worker, type: :model do
   describe "loading class" do
-    class FakeWorker
-      include Toiler::Worker
-      toiler_options queue: 'test_queue'
+    it "adds the class to the worker registry, under the queue name" do
+      class FakeWorker
+        include Toiler::Worker
+        toiler_options queue: 'test_queue'
 
-      def perform(sqs_message, body); end
-    end
+        def perform(sqs_message, body); end
+      end
 
-    it "adds the class to the toiler registry, under the queue name" do
       expect(Toiler.worker_class_registry['test_queue']).to eq(FakeWorker)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,3 +15,9 @@ class TestWorker
 end
 
 require 'rspec'
+RSpec.configure do |config|
+  config.before do
+    Toiler.worker_class_registry = {}
+    Toiler.register_worker('default', TestWorker)
+  end
+end


### PR DESCRIPTION
We have a number of different jobs, of varying importance and priority.  We want to be able to separate workers, so that a buildup in one queue won't affect processing in another queue

To this end, I added the concept of a ```Toiler.active_worker_class_registry``` that only includes workers that are actively working in an environment - either all queues, or a subset specified at runtime.

For example, we might have one box running
```$> bundle exec toiler -q essential_job_queue -C toiler.yml```
and another
```$> bundle exec toiler -q nonessential_job_queue1,nonessential_job_queue2 -C toiler.yml```

Interested to hear thoughts.