### PR TITLE
Trap ABRT signal for configurable graceful shutdown

### DIFF
--- a/lib/toiler.rb
+++ b/lib/toiler.rb
@@ -65,6 +65,7 @@ module Toiler
       auto_visibility_timeout: false,
       concurrency: 1,
       auto_delete: false,
+      shutdown_timeout: 5,
       batch: false
     }
   end

--- a/lib/toiler/cli.rb
+++ b/lib/toiler/cli.rb
@@ -67,7 +67,7 @@ module Toiler
     end
 
     def trap_signals
-      %w(INT TERM QUIT USR1 USR2 TTIN).each do |sig|
+      %w(INT TERM QUIT USR1 USR2 TTIN ABRT).each do |sig|
         begin
           trap sig do
             @self_write.puts(sig)
@@ -119,7 +119,7 @@ module Toiler
         print_status
       when 'INT', 'TERM'
         fail WaitShutdown, 60
-      when 'USR1'
+      when 'ABRT'
         fail WaitShutdown, Toiler.options[:shutdown_timeout] * 60
       end
     end

--- a/lib/toiler/cli.rb
+++ b/lib/toiler/cli.rb
@@ -43,12 +43,12 @@ module Toiler
         handle_signal(readable_io.first[0].gets.strip)
       end
     rescue WaitShutdown => shutdown_error
-      Toiler.logger.info 'Received Interrupt, Waiting up to 60 seconds for actors to finish...'
+      Toiler.logger.info "Received Interrupt, Waiting up to #{shutdown_error.wait} seconds for actors to finish..."
       success = supervisor.ask(:terminate!).wait(shutdown_error.wait)
       if success
         Toiler.logger.info 'Supervisor successfully terminated'
       else
-        Toiler.logger.info 'Timeout waiting dor Supervisor to terminate'
+        Toiler.logger.info 'Timeout waiting for Supervisor to terminate'
       end
     ensure
       exit 0
@@ -120,7 +120,7 @@ module Toiler
       when 'INT', 'TERM'
         fail WaitShutdown, 60
       when 'USR1'
-        fail WaitShutdown, 15*60
+        fail WaitShutdown, Toiler.options[:shutdown_timeout] * 60
       end
     end
 


### PR DESCRIPTION
Trap ABRT signal and wait a configurable amount of time before terminating the supervisor